### PR TITLE
Fixed: issue #98

### DIFF
--- a/src/main/resources/static/js/controllers/serviceController.js
+++ b/src/main/resources/static/js/controllers/serviceController.js
@@ -185,8 +185,6 @@ app.controller('ServiceCtrl', function ($scope, $interval, serviceAPI, $routePar
         if ($scope.projectChoice === undefined) {
             $scope.projectChoice = [];
             $scope.projectChoice = $scope.projects;
-            if ($scope.projectChoice !== undefined)
-                $scope.projectChoice.push({"name": "*"})
         }
     }
 


### PR DESCRIPTION
in projects variable "*" values was being added twice, once it loads the service page and 2nd time when you click on "add role" button. Because of this, it was showing double "*".. We just need to add "*" value when we want to add role in service not on page service page load.