### PR TITLE
fix: Double dash in get url

### DIFF
--- a/src/main/resources/static/js/controllers/eventController.js
+++ b/src/main/resources/static/js/controllers/eventController.js
@@ -146,7 +146,7 @@ app.controller('EventCtrl', function ($scope, $interval, serviceAPI, $routeParam
                     showError(data, status);
                 });
 
-            http.get(url + '/actions')
+            http.get(url + 'actions')
                 .success(function (response) {
                     $scope.actions = response;
                 })


### PR DESCRIPTION
Removes the double dash in the GET url on the event page. Currently "The request was rejected because the URL was not  normalized." with error 400 is thrown.